### PR TITLE
Fix event time being overridden when editing existing events

### DIFF
--- a/packages/frontend/src/hooks/use-absolute-relative-time-input.ts
+++ b/packages/frontend/src/hooks/use-absolute-relative-time-input.ts
@@ -13,7 +13,7 @@ export interface UseAbsoluteRelativeTimeInputReturn {
   handleRelativeDateChange: (relative: Duration) => void
 }
 
-type AbsoluteOrRelativeTime =
+export type AbsoluteOrRelativeTime =
   | { absolute: Dayjs }
   | { relative: Duration }
 
@@ -25,6 +25,7 @@ export function useAbsoluteRelativeTimeInput({
   time: initialTime,
 }: UseAbsoluteRelativeTimeInputOptions): UseAbsoluteRelativeTimeInputReturn {
   const [time, setTime] = useState(initialTime)
+  useEffect(() => setTime(initialTime), [initialTime])
 
   const handleChangeInputMode = useCallback((mode: TimeInputMode) => {
     setTime(time => {

--- a/packages/frontend/src/pages/timers/edit-event-dialog.tsx
+++ b/packages/frontend/src/pages/timers/edit-event-dialog.tsx
@@ -1,10 +1,13 @@
 import { ApiEventEntry, ApiEventEntryInput } from '@ping-board/common'
 import clsx from 'clsx'
-import { ChangeEvent, useEffect, useState } from 'react'
+import { ChangeEvent, useEffect, useMemo, useState } from 'react'
 import { Button, Col, Form, Modal, Row } from 'react-bootstrap'
 import { DateTimeInput } from '../../components/date-time-input'
 import { RelativeTimeInput } from '../../components/relative-time-input'
-import { useAbsoluteRelativeTimeInput } from '../../hooks/use-absolute-relative-time-input'
+import {
+  AbsoluteOrRelativeTime,
+  useAbsoluteRelativeTimeInput,
+} from '../../hooks/use-absolute-relative-time-input'
 import { dayjs } from '../../utils/dayjs'
 import './edit-event-dialog.scss'
 import { SolarSystemInput } from './solar-system-input'
@@ -49,16 +52,20 @@ export function EditEventDialog({
   onDelete,
 }: EditEventDialogProps): JSX.Element {
   const [editedEvent, setEditedEvent] = useState<EditedEvent>(getDefaultEditedEvent())
-  useEffect(() => setEditedEvent(event
-    ? { ...event }
-    : getDefaultEditedEvent()
-  ), [event])
+  const inputTime: AbsoluteOrRelativeTime = useMemo(() => event
+    ? { absolute: dayjs.utc(event.time) }
+    : { relative: dayjs.duration(0) }
+  , [event])
 
-  const timeInput = useAbsoluteRelativeTimeInput({
-    time: event
-      ? { absolute: dayjs.utc(event.time) }
-      : { relative: dayjs.duration(0) },
-  })
+  useEffect(() => {
+    console.log('replacing event', event, dayjs.utc(event?.time))
+    setEditedEvent(event
+      ? { ...event }
+      : getDefaultEditedEvent()
+    )
+  }, [event])
+
+  const timeInput = useAbsoluteRelativeTimeInput({ time: inputTime })
 
   const canSave = Object.entries(editedEvent ?? {}).every(([k, v]) => k === 'notes' || !!v)
   const save = () => {


### PR DESCRIPTION
As per #44, when editing an existing event, its time would be set to _now_ instead of keeping their original date.

Turns out the `useAbsoluteRelativeTimeInput` hook didn't update its state when its `time` input changed, so it always kept the time of the first event passed to the `EditEventDialog`. This first event would always be `null`, because initially the dialog isn't shown and we have to pass _something_ to the dialog.

---

Fix #44